### PR TITLE
update thermostat tile (target/current temps) from "thermostat" object

### DIFF
--- a/include/classTile.h
+++ b/include/classTile.h
@@ -57,8 +57,10 @@ protected:
   void _setIconTextFromIndex(void);
   void _freeImageHeap();
   void _hideIcon(bool hide);
+  bool _isThumbNail(const void *img);
+  void _hideThumbNail(bool hide);
 
-public :
+public : 
   tileId_t tileId;
   lv_obj_t *btn = NULL;
 

--- a/include/classTile.h
+++ b/include/classTile.h
@@ -134,4 +134,5 @@ public :
   int getThermostatCurrent(void);
   void setThermostatUnits(const char *units);
   const char *getThermostatUnits(void);
+  void updateThermostatDisplay(void);
 };

--- a/include/globalDefines.h
+++ b/include/globalDefines.h
@@ -71,9 +71,6 @@ typedef union
 #define CP_MODE_COLOR 0x01
 #define CP_MODE_TEMP 0x02
 
-// pseudo icon images (NO image, special handling)
-#define WP_PSEUDO_THERMOSTAT LV_IMG_CF_USER_ENCODED_0
-
 // symbols in wp_symbol_font_15
 #define WP_SYMBOL_DOTS "\xEF\x85\x82"
 #define WP_SYMBOL_CHEV_RIGHT "\xEF\x81\x94"

--- a/src/classes/classTile.cpp
+++ b/src/classes/classTile.cpp
@@ -843,8 +843,13 @@ const char *classTile::getThermostatUnits(void)
 
 void classTile::updateThermostatDisplay(void)
 {
-  String targetDisplay = String((float)_thermostatTarget / 10, 1);
-  String currentDisplay = String((float)_thermostatCurrent / 10, 1);
+  char displayTarget[10];
+  char displayCurrent[10];
+
+  sprintf(displayTarget, "%2.1f", (float)_thermostatTarget / 10.0);
+  sprintf(displayCurrent, "%2.1f", (float)_thermostatCurrent / 10.0);
+
+  const char * displayUnits = _units.c_str();
 
   if(_arcTarget)
   {
@@ -859,12 +864,12 @@ void classTile::updateThermostatDisplay(void)
     lv_obj_set_style_arc_color(_arcTarget, lv_color_hsv_to_rgb(h, s, 100), LV_PART_INDICATOR | LV_STATE_DEFAULT);
 
     // update the target/current values
-    lv_label_set_text_fmt(_labelArcValue, "%s %s", targetDisplay.c_str(), _units.c_str());
-    lv_label_set_text_fmt(_labelArcSubValue, "%s %s", currentDisplay.c_str(), _units.c_str());
+    lv_label_set_text_fmt(_labelArcValue, "%s %s", displayTarget, displayUnits);
+    lv_label_set_text_fmt(_labelArcSubValue, "%s %s", displayCurrent, displayUnits);
   }
   else
   {
     // no thermostat arc, so display temps as "indicator" values
-    setNumber(targetDisplay.c_str(), _units.c_str(), currentDisplay.c_str(), _units.c_str());
+    setNumber(displayTarget, displayUnits, displayCurrent, displayUnits);
   }
 }

--- a/src/classes/classTile.cpp
+++ b/src/classes/classTile.cpp
@@ -851,19 +851,21 @@ void classTile::updateThermostatDisplay(void)
 
   const char * displayUnits = _units.c_str();
 
-  if(_arcTarget)
+  if (_arcTarget)
   {
     int target = _thermostatTarget / ARC_STEP;
     lv_arc_set_value(_arcTarget, target);
+
     // calc hsv for arc coloring
     int range = (lv_arc_get_max_value(_arcTarget) - lv_arc_get_min_value(_arcTarget)) / 2;
     int mid = range + lv_arc_get_min_value(_arcTarget);
     int s = 50 + (abs(mid - target) * 50) / range;
+
     // red(360) or blue(240)
     int h = (target < mid) ? 240 : 360;
     lv_obj_set_style_arc_color(_arcTarget, lv_color_hsv_to_rgb(h, s, 100), LV_PART_INDICATOR | LV_STATE_DEFAULT);
 
-    // update the target/current values
+    // update the target/current display values
     lv_label_set_text_fmt(_labelArcValue, "%s %s", displayTarget, displayUnits);
     lv_label_set_text_fmt(_labelArcSubValue, "%s %s", displayCurrent, displayUnits);
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,9 +87,10 @@ extern "C" const lv_img_dsc_t ios_right_30;
 extern "C" const lv_img_dsc_t ios_slider_60;
 
 // pseudo icons
-const lv_img_dsc_t wp_pseudo_thermostat = 
+uint8_t nullImg[] = {0, 0, 0};
+const lv_img_dsc_t wp_pseudo_thermostat =
 {
-  WP_PSEUDO_THERMOSTAT, 0, 0, 0, 0, 0, NULL
+  LV_IMG_CF_TRUE_COLOR_ALPHA, 0, 0, 1, 1, sizeof(nullImg), nullImg
 };
 
 // image pointer for further reference


### PR DESCRIPTION
Previously you had to send both `thermostat` and `number` commands to keep the tile/popup in sync.

This change converts the `thermostat` values and updates the tile accordingly.

You might have a better way to handle the internal formatting?