### PR TITLE
add option to set individual tile background

### DIFF
--- a/include/classTile.h
+++ b/include/classTile.h
@@ -8,6 +8,7 @@ class classTile
 {
 protected:
   lv_obj_t *_parent = NULL;
+  lv_obj_t *_tileBg;
   lv_obj_t *_btn = NULL;
   lv_obj_t *_label = NULL;
   lv_obj_t *_subLabel = NULL;
@@ -51,6 +52,7 @@ protected:
   int _thermostatTarget = 0;
   int _thermostatCurrent = 0;
   string _units = "";
+  lv_color_t _tileBgColor = {0, 0, 0};
 
   void _button(lv_obj_t *parent, const void *img);
   void _reColorAll(lv_color_t color, lv_style_selector_t selector);
@@ -75,6 +77,7 @@ public :
   lv_color_t getColor();
   void setColor(lv_color_t color);
   void setColor(int r, int g, int b);
+  void setBgColor(int r, int g, int b);
   void setIcon(const void *imgIcon);
   void setNumber(const char *value, const char *units, const char *subValue, const char *subUnits);
   void setBgImage(lv_img_dsc_t *img);

--- a/src/classes/classTile.cpp
+++ b/src/classes/classTile.cpp
@@ -10,8 +10,16 @@ extern "C" const lv_font_t wp_symbol_font_15;
 void classTile::_button(lv_obj_t *parent, const void *img)
 {
   _parent = parent;
+  _tileBgColor = colorBg;
+  // create a background layer to opional configle tile backgroung
+  _tileBg = lv_obj_create(_parent);
+  lv_obj_remove_style_all(_tileBg);
+  lv_obj_set_style_radius(_tileBg, 5, LV_PART_MAIN);
+  lv_obj_set_style_bg_color(_tileBg, lv_color_hex(0xffffff), LV_PART_MAIN);
+  lv_obj_set_style_bg_opa(_tileBg, 0, LV_PART_MAIN);
+
   // create the image button as root parent for all content
-  _btn = lv_imgbtn_create(_parent);
+  _btn = lv_imgbtn_create(_tileBg);
   // placeholder for full image
   _imgBg = lv_img_create(_btn);
 
@@ -46,7 +54,7 @@ void classTile::_button(lv_obj_t *parent, const void *img)
       lv_obj_set_style_arc_opa(_arcTarget, 255, LV_PART_INDICATOR | LV_STATE_DEFAULT);
       lv_obj_set_style_arc_width(_arcTarget, 4, LV_PART_INDICATOR | LV_STATE_DEFAULT);
 
-      lv_obj_set_style_bg_color(_arcTarget, lv_color_lighten(colorBg, WP_OPA_BG_OFF), LV_PART_KNOB | LV_STATE_DEFAULT);
+      lv_obj_set_style_bg_color(_arcTarget, lv_color_lighten(_tileBgColor, WP_OPA_BG_OFF), LV_PART_KNOB | LV_STATE_DEFAULT);
       lv_obj_set_style_bg_opa(_arcTarget, 255, LV_PART_KNOB | LV_STATE_DEFAULT);
       lv_obj_set_style_border_color(_arcTarget, lv_color_hex(0xC8C8C8), LV_PART_KNOB | LV_STATE_DEFAULT);
       lv_obj_set_style_border_opa(_arcTarget, 255, LV_PART_KNOB | LV_STATE_DEFAULT);
@@ -140,9 +148,12 @@ void classTile::_button(lv_obj_t *parent, const void *img)
   lv_label_set_recolor(_txtIconText, true);
   lv_obj_add_flag(_txtIconText, LV_OBJ_FLAG_HIDDEN);
  
-  // set button and label size from grid
+  // set tile bg, button and label size from grid
   int width = *lv_obj_get_style_grid_column_dsc_array(parent, 0) - 10;
   int height = *lv_obj_get_style_grid_row_dsc_array(parent, 0) - 10;
+
+  lv_obj_set_width(_tileBg, width);
+  lv_obj_set_height(_tileBg, height);
 
   lv_obj_set_width(_btn, width);
   lv_obj_set_height(_btn, height);
@@ -259,7 +270,7 @@ void classTile::registerTile(int screenIdx, int tileIdx, int style, const char* 
   // position tile in grid after tile and screen are known
   int row = (tileIdx - 1) / 2;
   int col = (tileIdx - 1) % 2;
-  lv_obj_set_grid_cell(_btn, LV_GRID_ALIGN_CENTER, col, 1, LV_GRID_ALIGN_CENTER, row, 1);
+  lv_obj_set_grid_cell(_tileBg, LV_GRID_ALIGN_CENTER, col, 1, LV_GRID_ALIGN_CENTER, row, 1);
 }
 
 void classTile::setLabel(const char *labelText)
@@ -331,6 +342,25 @@ void classTile::setColor(int r, int g, int b)
   {
     setColor(lv_color_make(r, g, b));
   }
+}
+
+void classTile::setBgColor(int r, int g, int b)
+{
+  if ((r + g + b) == 0)
+  {
+    // if all zero reset to default background
+    lv_obj_set_style_bg_color(_tileBg, lv_color_hex(0xffffff), LV_PART_MAIN);
+    lv_obj_set_style_bg_opa(_tileBg, 0, LV_PART_MAIN);
+    _tileBgColor = colorBg;
+  }
+  else
+  {
+    lv_obj_set_style_bg_color(_tileBg, lv_color_make(r, g, b), LV_PART_MAIN);
+    lv_obj_set_style_bg_opa(_tileBg, 255, LV_PART_MAIN);
+    _tileBgColor = lv_color_make(r, g, b);
+  }
+  if (_arcTarget)
+    lv_obj_set_style_bg_color(_arcTarget, lv_color_lighten(_tileBgColor, WP_OPA_BG_OFF), LV_PART_KNOB | LV_STATE_DEFAULT);
 }
 
 void classTile::setNumber(const char *value, const char *units, const char *subValue, const char *subUnits)
@@ -639,10 +669,10 @@ void classTile::showOvlBar(int level)
   // set mode to bottom-up(default)  or top-down
   if (!_topDownMode)
   {
-    lv_obj_set_style_bg_color(_bar, lv_color_lighten(colorBg, 200), LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_bg_color(_bar, lv_color_lighten(_tileBgColor, 200), LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_bg_opa(_bar, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
 
-    lv_obj_set_style_bg_color(_bar, lv_color_lighten(colorBg, 50), LV_PART_INDICATOR | LV_STATE_DEFAULT);
+    lv_obj_set_style_bg_color(_bar, lv_color_lighten(_tileBgColor, 50), LV_PART_INDICATOR | LV_STATE_DEFAULT);
     lv_obj_set_style_bg_opa(_bar, 255, LV_PART_INDICATOR | LV_STATE_DEFAULT);
 
     lv_obj_set_style_bg_color(_bar, lv_color_lighten(colorOn, 150), LV_PART_MAIN | LV_STATE_CHECKED);
@@ -656,10 +686,10 @@ void classTile::showOvlBar(int level)
   }
   else
   {
-    lv_obj_set_style_bg_color(_bar, lv_color_lighten(colorBg, 50), LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_bg_color(_bar, lv_color_lighten(_tileBgColor, 50), LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_bg_opa(_bar, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
 
-    lv_obj_set_style_bg_color(_bar, lv_color_lighten(colorBg, 200), LV_PART_INDICATOR | LV_STATE_DEFAULT);
+    lv_obj_set_style_bg_color(_bar, lv_color_lighten(_tileBgColor, 200), LV_PART_INDICATOR | LV_STATE_DEFAULT);
     lv_obj_set_style_bg_opa(_bar, 255, LV_PART_INDICATOR | LV_STATE_DEFAULT);
 
     lv_obj_set_style_bg_color(_bar, lv_color_lighten(colorOn, 0), LV_PART_MAIN | LV_STATE_CHECKED);
@@ -747,7 +777,7 @@ void classTile::showSelector(int index)
 
   lv_obj_set_size(_roller, 70, 70);
   lv_obj_set_style_text_line_space(_roller, 8, LV_PART_MAIN);
-  lv_obj_set_style_bg_color(_roller, lv_color_lighten(colorBg, 50), LV_PART_MAIN);
+  lv_obj_set_style_bg_color(_roller, lv_color_lighten(_tileBgColor, 50), LV_PART_MAIN);
   lv_obj_set_style_bg_opa(_roller, 255, LV_PART_MAIN);
 
   lv_obj_set_style_bg_color(_roller, colorOn, LV_PART_SELECTED);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1782,6 +1782,15 @@ void jsonTileCommand(JsonVariant json)
     tile->setColor(r, g, b);
   }
 
+  if (json.containsKey("backgroundColorRgb"))
+  {
+    r = (uint8_t)json["backgroundColorRgb"]["r"].as<int>();
+    g = (uint8_t)json["backgroundColorRgb"]["g"].as<int>();
+    b = (uint8_t)json["backgroundColorRgb"]["b"].as<int>();
+
+    tile->setBgColor(r, g, b);
+  }
+
   if (json.containsKey("icon"))
   {
     tile->setIcon(iconVault.getIcon(json["icon"]));


### PR DESCRIPTION

```json
{
  "tiles":[
    {
      "screen":<number>,
      "tile":<number>,
      "backgroundColorRgb":{
        "r": <number>,
        "g": <number>,
        "b": <number>
      }
    }
  ]
} 

```


closes #16