### PR TITLE
add option to disable a tile

### DIFF
--- a/include/classTile.h
+++ b/include/classTile.h
@@ -8,7 +8,8 @@ class classTile
 {
 protected:
   lv_obj_t *_parent = NULL;
-  lv_obj_t *_tileBg;
+  lv_obj_t *_tileBg = NULL;
+  lv_obj_t *_tileFg = NULL;
   lv_obj_t *_btn = NULL;
   lv_obj_t *_label = NULL;
   lv_obj_t *_subLabel = NULL;
@@ -89,6 +90,7 @@ public :
   void setIconText(const char *iconText);
   void getImages(const void* &imgOff, const void* &imgOn);
   void setActionIndicator(const char* symbol);
+  void setTileDisabled(bool disable);
 
   int getLink(void);
   tileId_t getId(void);

--- a/src/classes/classTile.cpp
+++ b/src/classes/classTile.cpp
@@ -148,11 +148,8 @@ void classTile::_button(lv_obj_t *parent, const void *img)
   int width = *lv_obj_get_style_grid_column_dsc_array(parent, 0) - 10;
   int height = *lv_obj_get_style_grid_row_dsc_array(parent, 0) - 10;
 
-  lv_obj_set_width(_tileBg, width);
-  lv_obj_set_height(_tileBg, height);
-
-  lv_obj_set_width(_btn, width);
-  lv_obj_set_height(_btn, height);
+  lv_obj_set_size(_tileBg, width, height);
+  lv_obj_set_size(_btn, width, height);
 
   lv_obj_set_size(_label, width - 10, LV_SIZE_CONTENT);
   lv_obj_set_size(_subLabel, width - 10, LV_SIZE_CONTENT);
@@ -287,6 +284,33 @@ void classTile::registerTile(int screenIdx, int tileIdx, int style, const char* 
   int row = (tileIdx - 1) / 2;
   int col = (tileIdx - 1) % 2;
   lv_obj_set_grid_cell(_tileBg, LV_GRID_ALIGN_CENTER, col, 1, LV_GRID_ALIGN_CENTER, row, 1);
+}
+
+// cover tile with grey semi transparent layer to put into disabled state 
+void classTile::setTileDisabled(bool disable)
+{
+  if (disable)
+  {
+    int row = (tileId.idx.tile - 1) / 2;
+    int col = (tileId.idx.tile - 1) % 2;
+
+    _tileFg = lv_obj_create(_btn);
+    lv_obj_remove_style_all(_tileFg);
+    lv_obj_set_size(_tileFg, lv_obj_get_width(_btn), lv_obj_get_height(_btn));
+    lv_obj_set_style_radius(_tileFg, 5, LV_PART_MAIN);
+    lv_obj_set_grid_cell(_tileFg, LV_GRID_ALIGN_CENTER, col, 1, LV_GRID_ALIGN_CENTER, row, 1);
+    lv_obj_set_style_bg_color(_tileFg, lv_color_hex(0x606060), LV_PART_MAIN);
+    lv_obj_set_style_bg_opa(_tileFg, 160, LV_PART_MAIN);
+    lv_obj_move_foreground(_tileFg);
+  } 
+  else
+  {
+    if (_tileFg)
+    {
+    lv_obj_del(_tileFg);
+    _tileFg = NULL;
+    }
+  }
 }
 
 void classTile::setLabel(const char *labelText)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1808,6 +1808,11 @@ void jsonTileCommand(JsonVariant json)
     tile->setIconText(json["text"]);
   }
 
+  if (json.containsKey("disable"))
+  {
+    tile->setTileDisabled(json["disable"]);
+  }
+
   if (json.containsKey("backgroundImage"))
   {
     JsonVariant jsonBgImage = json["backgroundImage"];


### PR DESCRIPTION
Add an option to disable a tile.
A disabled tile doesn't accept touch events and the tile is greyed out.
cmnd/ payload  `{"tiles":[{"screen":"1", "tile":"3","disable":true}]}`
![grafik](https://user-images.githubusercontent.com/53935853/188327300-73d68a90-b41d-4a97-bac0-cb44ef357e51.png)

closes #23 