### PR TITLE
allow to set single screen background color

### DIFF
--- a/include/classScreen.h
+++ b/include/classScreen.h
@@ -1,6 +1,8 @@
 ﻿#pragma once
 #include <lvgl.h>
 
+#define TP_COLOR_BG_OVERWRITE LV_OBJ_FLAG_USER_1
+
 class classScreen
 {
 private:
@@ -16,6 +18,7 @@ private:
   lv_obj_t *_labelCenter = NULL;
   lv_obj_t *_labelRight = NULL;
 
+  lv_color_t _screenBgColor = {0, 0, 0};
   bool _hidden = false;
 
 public:
@@ -35,6 +38,8 @@ public:
   
   void setFooter(const char *left, const char *center, const char *right);
 
+  void setBgColor(int r, int g, int b);
+  lv_color_t getBgColor(void);
   void updateBgColor(void);
   void createHomeButton(lv_event_cb_t callBack, const void *img);
   void createSettingsButton(lv_event_cb_t callBack, const void *img);

--- a/include/classTile.h
+++ b/include/classTile.h
@@ -1,13 +1,14 @@
 ﻿#pragma once
 #include <lvgl.h>
 #include <globalDefines.h>
+#include <classScreen.h>
 
 #define ARC_STEP 5
 
 class classTile
 {
 protected:
-  lv_obj_t *_parent = NULL;
+  lv_obj_t *_parentContainer = NULL;
   lv_obj_t *_tileBg = NULL;
   lv_obj_t *_tileFg = NULL;
   lv_obj_t *_btn = NULL;
@@ -28,8 +29,7 @@ protected:
   lv_obj_t *_labelArcValue = NULL;
   lv_obj_t *_labelArcSubValue = NULL;
 
-  int _screenIdx = 0;
-  int _tileIdx = 0;
+  classScreen *_parentScreen = NULL;
   int _style = 0;
   string _styleStr;
   int _linkedScreen = 0;
@@ -68,30 +68,27 @@ public :
   lv_obj_t *btn = NULL;
 
   classTile(void){};
-  classTile(lv_obj_t *parent, const void *img);
-  classTile(lv_obj_t *parent, const void *img, const char *labelText);
   ~classTile();
 
-  void begin(lv_obj_t *parent, const void *img, const char *labelText);
-  void registerTile(int screenIdx, int tileIdx, int style, const char* styleStr);
-  void setLabel(const char *labelText);
+  void begin(lv_obj_t *parent, classScreen *parentScreen, int tileIdx, const void *img, const char *labelText, int style, const char* styleStr);
   void setSubLabel(const char *subLabelText);
   void setState(bool state);
-  lv_color_t getColor();
   void setColor(lv_color_t color);
   void setColor(int r, int g, int b);
+  lv_color_t getColor();
   void setBgColor(int r, int g, int b);
+  void updateBgColor(void);
   void setIcon(const void *imgIcon);
   void setNumber(const char *value, const char *units, const char *subValue, const char *subUnits);
   void setBgImage(lv_img_dsc_t *img);
   void alignBgImage(int zoom, int posOffsX, int posOffsY, int angle);
-  void setLink(int linkedScreen);
   void setIconForStateOn(const void* imgStateOn);
   void setIconText(const char *iconText);
   void getImages(const void* &imgOff, const void* &imgOn);
   void setActionIndicator(const char* symbol);
   void setTileDisabled(bool disable);
 
+  void setLink(int linkedScreen);
   int getLink(void);
   tileId_t getId(void);
   int getScreenIdx(void);

--- a/include/classTileList.h
+++ b/include/classTileList.h
@@ -11,6 +11,8 @@ public:
   classTile &add(void);
   classTile *get(int screenIdx, int tileIdx);
   void remove(int screenIdx, int tileIdx);
+  void setIteratorStart(void);
+  classTile *getNextTile(void);
  
   int getSize(void);
 };

--- a/src/classes/classScreen.cpp
+++ b/src/classes/classScreen.cpp
@@ -1,10 +1,8 @@
 ﻿#include <classScreen.h>
-#include <classTile.h>
 #include <globalDefines.h>
 
 extern lv_color_t colorOn;
 extern lv_color_t colorBg;
-// extern classScreen *screenDsc[9];
 
 // grid definitions
 // sub screens 3 x 2 + home button
@@ -23,6 +21,7 @@ classScreen::classScreen(int number, int style)
   screen = lv_obj_create(NULL);
   lv_obj_clear_flag(screen, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_set_style_bg_color(screen, colorBg, LV_PART_MAIN);
+  lv_obj_clear_flag(screen, TP_COLOR_BG_OVERWRITE);
 
   if (style == 1)
   {
@@ -153,9 +152,32 @@ void classScreen::setFooter(const char *left, const char *center, const char *ri
   }
 }
 
+void classScreen::setBgColor(int r, int g, int b)
+{
+  if ((r + g + b) == 0)
+  {
+    // if all zero reset to default background
+    lv_obj_clear_flag(screen, TP_COLOR_BG_OVERWRITE);
+    _screenBgColor = colorBg;
+  }
+  else
+  {
+    lv_obj_add_flag(screen, TP_COLOR_BG_OVERWRITE);
+    _screenBgColor = lv_color_make(r, g, b);
+  }
+  updateBgColor();
+}
+
 void classScreen::updateBgColor(void)
 {
-  lv_obj_set_style_bg_color(screen, colorBg, LV_PART_MAIN);
+  if (!lv_obj_has_flag(screen, TP_COLOR_BG_OVERWRITE))
+    _screenBgColor = colorBg;
+  lv_obj_set_style_bg_color(screen, _screenBgColor, LV_PART_MAIN);
+}
+
+lv_color_t classScreen::getBgColor(void)
+{
+  return _screenBgColor;
 }
 
 void classScreen::createHomeButton(lv_event_cb_t callBack, const void *img)

--- a/src/classes/classTileList.cpp
+++ b/src/classes/classTileList.cpp
@@ -6,6 +6,7 @@ using std::list;
 
 // THE list that holds all tiles
 std::list<classTile> _listTiles;
+std::list<classTile>::iterator _itNext;
 
 classTile &classTileList::add(void)
 {
@@ -47,4 +48,23 @@ void classTileList::remove(int screenIdx, int tileIdx)
 int classTileList::getSize(void)
 {
   return _listTiles.size();
+}
+
+// return size from list
+void classTileList::setIteratorStart(void)
+{
+  _itNext = _listTiles.begin();
+}
+
+// return size from list
+classTile *classTileList::getNextTile(void)
+{
+  if (_itNext == _listTiles.end())
+  {
+    return NULL;
+  }
+  else
+  {
+    return _itNext++.operator->();
+  }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1202,8 +1202,7 @@ void createTile(const char *styleStr, int screenIdx, int tileIdx, const char *ic
 
   // create new Tile
   classTile &ref = tileVault.add();
-  ref.begin(screenVault.get(screenIdx)->container, img, label);
-  ref.registerTile(screenIdx, tileIdx, style, styleStr);
+  ref.begin(screenVault.get(screenIdx)->container, screenVault.get(screenIdx), tileIdx, img, label, style, styleStr);
 
   // handle tiles depending on style capabilities
   if ((style == TS_LINK) && linkedScreen)
@@ -1375,6 +1374,15 @@ void getApiSnapshot(Request &req, Response &res)
  * Config Handler
  */
 
+void updateTilesBgColor(void)
+{
+  tileVault.setIteratorStart();
+  while (classTile *tile = tileVault.getNextTile())
+  {
+    tile->updateBgColor();
+  }
+}
+
 void jsonIconOnColorConfig(JsonVariant json)
 {
   uint8_t r, g, b;
@@ -1401,6 +1409,8 @@ void jsonBackgroundColorConfig(JsonVariant json)
   {
     if (sPtr) sPtr->updateBgColor();
   } while ((sPtr = screenVault.getNext(sPtr->screenIdx)));
+  // update all tiles
+  updateTilesBgColor();
 }
 
 void jsonTilesConfig(int screenIdx, JsonVariant json)
@@ -1692,6 +1702,17 @@ void jsonScreenCommand(JsonVariant json)
     wt32.print(F("[tp32] screen not found: "));
     wt32.println(screenIdx);
     return;
+  }
+
+  if (json.containsKey("backgroundColorRgb"))
+  {
+    uint8_t r = (uint8_t)json["backgroundColorRgb"]["r"].as<int>();
+    uint8_t g = (uint8_t)json["backgroundColorRgb"]["g"].as<int>();
+    uint8_t b = (uint8_t)json["backgroundColorRgb"]["b"].as<int>();
+
+    screen->setBgColor(r, g, b);
+    // announce tiles about BG change
+    updateTilesBgColor();
   }
 
   if (json.containsKey("footer"))


### PR DESCRIPTION
Payload to set screen specific bg color as proposed by Ben
```
{
    "screens": [
        {
            "screen": 1,
            "backgroundColorRgb": {
                "r": 255,
                "g": 0,
                "b": 0
            }
        }
    ]
}
```
the bg-color-layers act hierarchical:
When a higer layer (tile(high) -> screen -> colorBg(low)) has been set with its own bgColor it will not fall back when a lower layer changes color.
All children of a tile are drawn with the correct bg color - 
Bug fixed : The knob of the thermostat thumbnail wasn't colored properly

The pop-ups still using the system `colorBg`
