### PR TITLE
add cmnd/ payloads for screen and tile removal

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1719,6 +1719,24 @@ void jsonScreenCommand(JsonVariant json)
     return;
   }
 
+ if (json.containsKey("action"))
+  {
+    if (strcmp(json["action"], "remove") == 0)
+    {
+      for (int tileIdx = TILE_START; tileIdx <= TILE_END; tileIdx++)
+      {
+        tileVault.remove(screenIdx, tileIdx);
+      }
+      screenVault.remove(screenIdx);
+      if (screenIdx == SCREEN_HOME)
+        createScreen(SCREEN_HOME);
+
+      screenVault.show(SCREEN_HOME);
+      // early exit after screen removed
+      return;
+    }
+  }
+ 
   if (json.containsKey("backgroundColorRgb"))
   {
     uint8_t r = (uint8_t)json["backgroundColorRgb"]["r"].as<int>();
@@ -1764,6 +1782,25 @@ void jsonTileCommand(JsonVariant json)
     wt32.print(F("/"));
     wt32.println(tileIdx);
     return;
+  }
+
+  if (json.containsKey("action"))
+  {
+    JsonVariant jsonAction = json["action"];
+    if (strcmp(jsonAction, "remove") == 0)
+    {
+      tileVault.remove(screenIdx, tileIdx);
+      // early exit after tile removed
+      return;
+    }
+    if (strcmp(jsonAction, "enable") == 0)
+    {
+      tile->setTileDisabled(false);
+    }
+    if (strcmp(jsonAction, "disable") == 0)
+    {
+      tile->setTileDisabled(true);
+    }
   }
 
   if (json.containsKey("state"))
@@ -1839,11 +1876,6 @@ void jsonTileCommand(JsonVariant json)
   if (json.containsKey("text"))
   {
     tile->setIconText(json["text"]);
-  }
-
-  if (json.containsKey("disable"))
-  {
-    tile->setTileDisabled(json["disable"]);
   }
 
   if (json.containsKey("backgroundImage"))


### PR DESCRIPTION
- tile "disable" has moved to "action":"disable"|"enable"

new cmnd/ payloads to remove screens and tiles

**remove screen:**
```
{
  "screens": [
    { "screen": 2, "action": "remove" }
  ]
}
```
**remove tile:**
```
{
  "tiles": [
    { "screen": 1, "tile": 2, "action": "remove" }
  ]
}
```
braking change : keyword "disable" for tiles removed
new "action"
**disable / enable tile:**
```
{
  "tiles": [
    { "screen": 1, "tile": 2, "action": "disable" | "enable" }
  ]
}
```

rules:
- removing a screen removes all tiles on this screen as well
- removing sreen 1 (Home Screen) technically removes screen 1 and creates an empty screen 1 (Home Screen)


closes #33 
closes #40 
