### PR TITLE
symplified internal jsonColorRgb handling

### DIFF
--- a/include/classScreen.h
+++ b/include/classScreen.h
@@ -38,7 +38,7 @@ public:
   
   void setFooter(const char *left, const char *center, const char *right);
 
-  void setBgColor(int r, int g, int b);
+  void setBgColor(lv_color_t color);
   lv_color_t getBgColor(void);
   void updateBgColor(void);
   void createHomeButton(lv_event_cb_t callBack, const void *img);

--- a/include/classTile.h
+++ b/include/classTile.h
@@ -94,9 +94,8 @@ public :
   void setSubLabel(const char *subLabelText);
   void setState(bool state);
   void setColor(lv_color_t color);
-  void setColor(int r, int g, int b);
   lv_color_t getColor();
-  void setBgColor(int r, int g, int b);
+  void setBgColor(lv_color_t color);
   void updateBgColor(void);
   void setIcon(const void *imgIcon);
   void setNumber(const char *value, const char *units, const char *subValue, const char *subUnits);

--- a/src/classes/classScreen.cpp
+++ b/src/classes/classScreen.cpp
@@ -152,9 +152,9 @@ void classScreen::setFooter(const char *left, const char *center, const char *ri
   }
 }
 
-void classScreen::setBgColor(int r, int g, int b)
+void classScreen::setBgColor(lv_color_t color)
 {
-  if ((r + g + b) == 0)
+  if (color.full == 0)
   {
     // if all zero reset to default background
     lv_obj_clear_flag(screen, TP_COLOR_BG_OVERWRITE);
@@ -163,7 +163,7 @@ void classScreen::setBgColor(int r, int g, int b)
   else
   {
     lv_obj_add_flag(screen, TP_COLOR_BG_OVERWRITE);
-    _screenBgColor = lv_color_make(r, g, b);
+    _screenBgColor = color;
   }
   updateBgColor();
 }

--- a/src/classes/classTile.cpp
+++ b/src/classes/classTile.cpp
@@ -345,21 +345,9 @@ lv_color_t classTile::getColor()
 
 void classTile::setColor(lv_color_t color)
 {
-  if (lv_obj_get_state(_btn) & LV_STATE_CHECKED)
-  {
-    _reColorAll(color, LV_STATE_CHECKED);
-  }
-  else
-  {
-    _reColorAll(color, LV_IMGBTN_STATE_RELEASED);
-  }
-}
-
-void classTile::setColor(int r, int g, int b)
-{
-  if ((r + g + b) == 0)
-  {
     // if all zero reset to default color
+  if (color.full == 0)
+  {
     if (lv_obj_get_state(_btn) & LV_STATE_CHECKED)
     {
       _reColorAll(colorOn, LV_STATE_CHECKED);
@@ -371,13 +359,20 @@ void classTile::setColor(int r, int g, int b)
   }
   else
   {
-    setColor(lv_color_make(r, g, b));
+    if (lv_obj_get_state(_btn) & LV_STATE_CHECKED)
+    {
+      _reColorAll(color, LV_STATE_CHECKED);
+    }
+    else
+    {
+      _reColorAll(color, LV_IMGBTN_STATE_RELEASED);
+    }
   }
 }
 
-void classTile::setBgColor(int r, int g, int b)
+void classTile::setBgColor(lv_color_t color)
 {
-  if ((r + g + b) == 0)
+  if (color.full == 0)
   {
     // if all zero reset to default background
     lv_obj_clear_flag(_tileBg, TP_COLOR_BG_OVERWRITE);
@@ -386,7 +381,7 @@ void classTile::setBgColor(int r, int g, int b)
   else
   {
     lv_obj_add_flag(_tileBg, TP_COLOR_BG_OVERWRITE);
-    _tileBgColor = lv_color_make(r, g, b);
+    _tileBgColor = color;
   }
   updateBgColor();
 }


### PR DESCRIPTION
I symplified the internal `jsonColorRgb `handling. A common function converts the json array to a `lv_color_t `which is used internally instead of the` r,g,b's`