### PR TITLE
Make tile opacity configurable

### DIFF
--- a/include/classTile.h
+++ b/include/classTile.h
@@ -84,7 +84,6 @@ protected:
   void _createIconText(void);
   void _reColorAll(lv_color_t color, lv_style_selector_t selector);
   void _setIconTextFromIndex(void);
-  void _freeImageHeap();
   void _hideIcon(bool hide);
   bool _isThumbNail(const void *img);
   void _hideThumbNail(bool hide);
@@ -97,6 +96,7 @@ public :
   ~classTile();
 
   void begin(lv_obj_t *parent, classScreen *parentScreen, int tileIdx, const void *img, const char *labelText, int style, const char* styleStr);
+  void setLabel(const char *labelText);
   void setSubLabel(const char *subLabelText);
   void setState(bool state);
   void setColor(lv_color_t color);

--- a/include/globalDefines.h
+++ b/include/globalDefines.h
@@ -47,11 +47,18 @@ typedef struct
   const void *img;
 } imgListElement_t;
 
-#define WP_OPA_BG_OFF     26
-#define WP_OPA_BG_ON      255
+// definitions in int units
 #define WP_OPA_BG_50      128
 #define WP_OPA_BG_70      178
 #define WP_OPA_BG_PRESSED 128
+
+// definitions in % for API
+#define DEFAULT_TILE_BRIGHTNESS_OFF 10
+#define DEFAULT_TILE_BRIGHTNESS_ON  100
+#define TILE_BRIGHTNESS_OFF_MIN     0
+#define TILE_BRIGHTNESS_OFF_MAX     25
+#define TILE_BRIGHTNESS_ON_MIN      75
+#define TILE_BRIGHTNESS_ON_MAX      100
 
 // screen layout
 #ifndef SCREEN_WIDTH

--- a/src/classes/classColorPicker.cpp
+++ b/src/classes/classColorPicker.cpp
@@ -15,6 +15,8 @@ hsv_t _colorWheelHSV;
 
 extern lv_color_t colorOn;
 extern lv_color_t colorBg;
+extern int opaBgOff;
+extern int opaBgOn;
 extern const void *imgOnOff;
 
 // convert RGB to HSV with RGB888 and floating point calc
@@ -135,8 +137,8 @@ void classColorPicker::_createColorPicker(lv_img_dsc_t *imgCw)
   lv_obj_set_size(_btnColor, SCREEN_WIDTH / 2 - 7, 40);
   lv_obj_set_style_bg_color(_btnColor, lv_color_hex(0xffffff), LV_STATE_DEFAULT);
   lv_obj_set_style_bg_color(_btnColor, lv_color_hex(0xffffff), LV_STATE_CHECKED);
-  lv_obj_set_style_bg_opa(_btnColor, WP_OPA_BG_OFF, LV_STATE_DEFAULT);
-  lv_obj_set_style_bg_opa(_btnColor, WP_OPA_BG_ON, LV_STATE_CHECKED);
+  lv_obj_set_style_bg_opa(_btnColor, opaBgOff, LV_STATE_DEFAULT);
+  lv_obj_set_style_bg_opa(_btnColor, opaBgOn, LV_STATE_CHECKED);
   lv_obj_t *labelColor = lv_label_create(_btnColor);
   lv_label_set_text(labelColor, "Color");
   lv_obj_set_style_text_color(_btnColor, lv_color_hex(0x000000), LV_STATE_CHECKED);
@@ -148,8 +150,8 @@ void classColorPicker::_createColorPicker(lv_img_dsc_t *imgCw)
   lv_obj_set_size(_btnKelvin, SCREEN_WIDTH / 2 - 7, 40);
   lv_obj_set_style_bg_color(_btnKelvin, lv_color_hex(0xffffff), LV_STATE_DEFAULT);
   lv_obj_set_style_bg_color(_btnKelvin, lv_color_hex(0xffffff), LV_STATE_CHECKED);
-  lv_obj_set_style_bg_opa(_btnKelvin, WP_OPA_BG_OFF, LV_STATE_DEFAULT);
-  lv_obj_set_style_bg_opa(_btnKelvin, WP_OPA_BG_ON, LV_STATE_CHECKED);
+  lv_obj_set_style_bg_opa(_btnKelvin, opaBgOff, LV_STATE_DEFAULT);
+  lv_obj_set_style_bg_opa(_btnKelvin, opaBgOn, LV_STATE_CHECKED);
   lv_obj_t *labelKelvin = lv_label_create(_btnKelvin);
   lv_label_set_text(labelKelvin, "Temperature");
   lv_obj_set_style_text_color(_btnKelvin, lv_color_hex(0x000000), LV_STATE_CHECKED);
@@ -164,7 +166,7 @@ void classColorPicker::_createColorPicker(lv_img_dsc_t *imgCw)
   lv_obj_set_style_radius(_panelRGB, 5, LV_PART_MAIN | LV_STATE_DEFAULT);
   lv_obj_clear_flag(_panelRGB, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_set_style_bg_color(_panelRGB, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DEFAULT);
-  lv_obj_set_style_bg_opa(_panelRGB, WP_OPA_BG_OFF, LV_PART_MAIN | LV_STATE_DEFAULT);
+  lv_obj_set_style_bg_opa(_panelRGB, opaBgOff, LV_PART_MAIN | LV_STATE_DEFAULT);
   lv_obj_add_flag(_panelRGB, LV_OBJ_FLAG_HIDDEN);
 
   // label calling tile aat top
@@ -182,7 +184,7 @@ void classColorPicker::_createColorPicker(lv_img_dsc_t *imgCw)
   lv_obj_set_style_radius(_panelCCT, 5, LV_PART_MAIN | LV_STATE_DEFAULT);
   lv_obj_clear_flag(_panelCCT, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_set_style_bg_color(_panelCCT, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DEFAULT);
-  lv_obj_set_style_bg_opa(_panelCCT, WP_OPA_BG_OFF, LV_PART_MAIN | LV_STATE_DEFAULT);
+  lv_obj_set_style_bg_opa(_panelCCT, opaBgOff, LV_PART_MAIN | LV_STATE_DEFAULT);
   lv_obj_add_flag(_panelCCT, LV_OBJ_FLAG_HIDDEN);
 
   // label calling tile aat top
@@ -197,9 +199,9 @@ void classColorPicker::_createColorPicker(lv_img_dsc_t *imgCw)
   lv_obj_set_size(_btn, 153, 40);
   lv_obj_align(_btn, LV_ALIGN_BOTTOM_RIGHT, -5, -5);
   lv_obj_set_style_bg_color(_btn, lv_color_hex(0xffffff), LV_PART_MAIN | LV_STATE_DEFAULT);
-  lv_obj_set_style_bg_opa(_btn, WP_OPA_BG_OFF, LV_PART_MAIN | LV_STATE_DEFAULT);
+  lv_obj_set_style_bg_opa(_btn, opaBgOff, LV_PART_MAIN | LV_STATE_DEFAULT);
   lv_obj_set_style_bg_color(_btn, lv_color_hex(0xffffff), LV_PART_MAIN | LV_STATE_CHECKED);
-  lv_obj_set_style_bg_opa(_btn, WP_OPA_BG_ON, LV_PART_MAIN | LV_STATE_CHECKED);
+  lv_obj_set_style_bg_opa(_btn, opaBgOn, LV_PART_MAIN | LV_STATE_CHECKED);
 
   _imgBtn = lv_img_create(_btn);
   lv_obj_align(_imgBtn, LV_ALIGN_CENTER, 0, 0);

--- a/src/classes/classDropDown.cpp
+++ b/src/classes/classDropDown.cpp
@@ -3,6 +3,8 @@
 
 extern lv_color_t colorOn;
 extern lv_color_t colorBg;
+extern int opaBgOff;
+extern int opaBgOn;
 
 void classDropDown::_createDropDown(void)
 {
@@ -23,7 +25,7 @@ void classDropDown::_createDropDown(void)
   lv_obj_set_style_text_line_space(list, 30, LV_PART_MAIN);
   lv_obj_set_style_text_font(list, &lv_font_montserrat_20, 0);
   lv_obj_set_style_bg_color(list, lv_color_hex(0xffffff), LV_PART_MAIN);
-  lv_obj_set_style_bg_opa(list, WP_OPA_BG_OFF, LV_PART_MAIN);
+  lv_obj_set_style_bg_opa(list, opaBgOff, LV_PART_MAIN);
   lv_obj_set_style_radius(list, 5, LV_PART_SELECTED);
   lv_obj_set_style_bg_color(list, colorOn, LV_PART_SELECTED | LV_STATE_PRESSED);
   lv_obj_set_style_bg_color(list, colorOn, LV_PART_SELECTED | LV_STATE_CHECKED);

--- a/src/classes/classKeyPad.cpp
+++ b/src/classes/classKeyPad.cpp
@@ -4,6 +4,8 @@
 
 extern lv_color_t colorOn;
 extern lv_color_t colorBg;
+extern int opaBgOff;
+extern int opaBgOn;
 
 extern "C" const lv_font_t pwd_fond_15;
 
@@ -26,7 +28,7 @@ void classKeyPad::_createKeyPad(void)
   lv_obj_set_style_bg_opa(_btnm1, 0, LV_PART_MAIN);
   lv_obj_set_style_radius(_btnm1, 80, LV_PART_ITEMS);
   lv_obj_set_style_bg_color(_btnm1, lv_color_hex(0xffffff), LV_PART_ITEMS);
-  lv_obj_set_style_bg_opa(_btnm1, WP_OPA_BG_OFF, LV_PART_ITEMS);
+  lv_obj_set_style_bg_opa(_btnm1, opaBgOff, LV_PART_ITEMS);
   lv_obj_set_style_border_width(_btnm1, 0, LV_PART_MAIN);
 
   lv_obj_set_style_pad_row(_btnm1, 15, LV_PART_MAIN);

--- a/src/classes/classPopUpContainer.cpp
+++ b/src/classes/classPopUpContainer.cpp
@@ -3,6 +3,8 @@
 
 extern lv_color_t colorOn;
 extern lv_color_t colorBg;
+extern int opaBgOff;
+extern int opaBgOn;
 
 // build the panels with all widgets
 void classPopUpContainer::_startUp(void)
@@ -24,14 +26,14 @@ void classPopUpContainer::_startUp(void)
   lv_obj_set_style_radius(_panel, 5, LV_PART_MAIN | LV_STATE_DEFAULT);
   lv_obj_clear_flag(_panel, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_set_style_bg_color(_panel, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DEFAULT);
-  lv_obj_set_style_bg_opa(_panel, WP_OPA_BG_OFF, LV_PART_MAIN | LV_STATE_DEFAULT);
+  lv_obj_set_style_bg_opa(_panel, opaBgOff, LV_PART_MAIN | LV_STATE_DEFAULT);
 
   // back button (closes pop up)
   _btnExit = lv_btn_create(_ovlPanel);
   lv_obj_set_size(_btnExit, 153, 40);
   lv_obj_align(_btnExit, LV_ALIGN_BOTTOM_LEFT, 5, -5);
   lv_obj_set_style_bg_color(_btnExit, lv_color_hex(0xffffff), LV_PART_MAIN | LV_STATE_DEFAULT);
-  lv_obj_set_style_bg_opa(_btnExit, WP_OPA_BG_OFF, LV_PART_MAIN | LV_STATE_DEFAULT);
+  lv_obj_set_style_bg_opa(_btnExit, opaBgOff, LV_PART_MAIN | LV_STATE_DEFAULT);
   lv_obj_t *label = lv_label_create(_btnExit);
   lv_label_set_text(label, LV_SYMBOL_LEFT);
   lv_obj_align(label, LV_ALIGN_CENTER, 0, 0);

--- a/src/classes/classScreenSettings.cpp
+++ b/src/classes/classScreenSettings.cpp
@@ -4,6 +4,8 @@
 extern void _setBackLightLED(int val);
 extern lv_color_t colorOn;
 extern lv_color_t colorBg;
+extern int opaBgOff;
+extern int opaBgOn;
 
 static void _callBackRestart(lv_event_t *e)
 {
@@ -84,7 +86,7 @@ classScreenSettings::classScreenSettings(lv_obj_t *parent, const void *img)
   // reset button
   _btnRestart = lv_btn_create(_parent);
 
-  lv_obj_set_style_bg_opa(_btnRestart, WP_OPA_BG_OFF, LV_PART_MAIN | LV_IMGBTN_STATE_RELEASED);
+  lv_obj_set_style_bg_opa(_btnRestart, opaBgOff, LV_PART_MAIN | LV_IMGBTN_STATE_RELEASED);
   lv_obj_set_style_img_recolor(_btnRestart, lv_color_hex(0xffffff), LV_PART_MAIN | LV_IMGBTN_STATE_RELEASED);
   lv_obj_set_style_img_recolor_opa(_btnRestart, 255, LV_PART_MAIN | LV_IMGBTN_STATE_RELEASED);
   lv_obj_set_size(_btnRestart, 150, 50);

--- a/src/classes/classThermostat.cpp
+++ b/src/classes/classThermostat.cpp
@@ -3,6 +3,8 @@
 
 extern lv_color_t colorOn;
 extern lv_color_t colorBg;
+extern int opaBgOff;
+extern int opaBgOn;
 extern "C" const lv_font_t number_OR_50;
 
 // build the panels with all widgets
@@ -32,7 +34,7 @@ void classThermostat::_createThermostat(void)
   lv_obj_set_style_arc_opa(_arcTarget, 255, LV_PART_INDICATOR | LV_STATE_DEFAULT);
   lv_obj_set_style_arc_width(_arcTarget, 5, LV_PART_INDICATOR | LV_STATE_DEFAULT);
 
-  lv_obj_set_style_bg_color(_arcTarget, lv_color_lighten(colorBg, WP_OPA_BG_OFF), LV_PART_KNOB | LV_STATE_DEFAULT);
+  lv_obj_set_style_bg_color(_arcTarget, lv_color_lighten(colorBg, opaBgOff), LV_PART_KNOB | LV_STATE_DEFAULT);
   lv_obj_set_style_bg_opa(_arcTarget, 255, LV_PART_KNOB | LV_STATE_DEFAULT);
   lv_obj_set_style_border_color(_arcTarget, lv_color_hex(0xC8C8C8), LV_PART_KNOB | LV_STATE_DEFAULT);
   lv_obj_set_style_border_opa(_arcTarget, 255, LV_PART_KNOB | LV_STATE_DEFAULT);
@@ -68,7 +70,7 @@ void classThermostat::_createThermostat(void)
   _btnMode = lv_btn_create(_panel);
   lv_obj_set_size(_btnMode, 150, 40);
   lv_obj_align(_btnMode, LV_ALIGN_BOTTOM_MID, 0, -40);
-  lv_obj_set_style_bg_color(_btnMode, lv_color_lighten(colorBg, WP_OPA_BG_OFF * 2), LV_PART_MAIN | LV_STATE_DEFAULT);
+  lv_obj_set_style_bg_color(_btnMode, lv_color_lighten(colorBg, opaBgOff * 2), LV_PART_MAIN | LV_STATE_DEFAULT);
   lv_obj_set_style_bg_opa(_btnMode, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
   _labelMode = lv_label_create(_btnMode);
   lv_label_set_text(_labelMode, "");
@@ -81,7 +83,7 @@ void classThermostat::_createThermostat(void)
   lv_obj_set_size(_dropDown, 250, LV_SIZE_CONTENT);
   lv_obj_align(_dropDown, LV_ALIGN_BOTTOM_MID, 00, -40);
   lv_obj_set_style_border_width(_dropDown, 0, LV_PART_MAIN);
-  lv_obj_set_style_bg_color(_dropDown, lv_color_lighten(colorBg, WP_OPA_BG_OFF * 2), LV_PART_MAIN);
+  lv_obj_set_style_bg_color(_dropDown, lv_color_lighten(colorBg, opaBgOff * 2), LV_PART_MAIN);
   lv_obj_set_style_bg_opa(_dropDown, 255, LV_PART_MAIN);
   lv_dropdown_set_options(_dropDown, "empty");
   lv_obj_set_style_text_align(_dropDown, LV_ALIGN_CENTER, LV_PART_MAIN);
@@ -91,7 +93,7 @@ void classThermostat::_createThermostat(void)
   lv_obj_set_style_border_width(list, 0, LV_PART_MAIN);
   lv_obj_set_style_text_line_space(list, 30, LV_PART_MAIN);
   lv_obj_set_style_text_font(list, &lv_font_montserrat_20, 0);
-  lv_obj_set_style_bg_color(list, lv_color_lighten(colorBg, WP_OPA_BG_OFF * 2), LV_PART_MAIN);
+  lv_obj_set_style_bg_color(list, lv_color_lighten(colorBg, opaBgOff * 2), LV_PART_MAIN);
   lv_obj_set_style_bg_opa(list, 255, LV_PART_MAIN);
   lv_obj_set_style_radius(list, 5, LV_PART_SELECTED);
   lv_obj_set_style_bg_color(list, colorOn, LV_PART_SELECTED | LV_STATE_PRESSED);

--- a/src/classes/classTile.cpp
+++ b/src/classes/classTile.cpp
@@ -335,6 +335,11 @@ void classTile::setTileDisabled(bool disable)
   }
 }
 
+void classTile::setLabel(const char *labelText)
+{
+  lv_label_set_text(_label, labelText);
+}
+
 void classTile::setSubLabel(const char *subLabelText)
 {
   lv_label_set_text(_subLabel, subLabelText);

--- a/src/classes/classTile.cpp
+++ b/src/classes/classTile.cpp
@@ -2,6 +2,9 @@
 #include <globalDefines.h>
 
 extern lv_color_t colorOn;
+extern int opaBgOff;
+extern int opaBgOn;
+
 extern "C" const lv_font_t number_OR_50;
 extern "C" const lv_font_t wp_symbol_font_15;
 
@@ -23,7 +26,7 @@ void classTile::_button(lv_obj_t *parent, const void *img)
   _fullBar = lv_obj_create(_tileBg);
   lv_obj_remove_style_all(_fullBar);
   lv_obj_set_style_bg_color(_fullBar, lv_color_hex(0xffffff), LV_PART_MAIN);
-  lv_obj_set_style_bg_opa(_fullBar, 255, LV_PART_MAIN | LV_STATE_CHECKED);
+  lv_obj_set_style_bg_opa(_fullBar, 255 - (255 - opaBgOn) * 2, LV_PART_MAIN | LV_STATE_CHECKED);
   lv_obj_set_style_bg_opa(_fullBar, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
   lv_obj_align(_fullBar, LV_ALIGN_TOP_MID, 0, 0);
 
@@ -60,7 +63,7 @@ void classTile::_button(lv_obj_t *parent, const void *img)
       lv_obj_set_style_arc_opa(_arcTarget, 255, LV_PART_INDICATOR | LV_STATE_DEFAULT);
       lv_obj_set_style_arc_width(_arcTarget, 4, LV_PART_INDICATOR | LV_STATE_DEFAULT);
 
-      lv_obj_set_style_bg_color(_arcTarget, lv_color_lighten(_tileBgColor, WP_OPA_BG_OFF), LV_PART_KNOB | LV_STATE_DEFAULT);
+      lv_obj_set_style_bg_color(_arcTarget, lv_color_lighten(_tileBgColor, opaBgOff), LV_PART_KNOB | LV_STATE_DEFAULT);
       lv_obj_set_style_bg_opa(_arcTarget, 255, LV_PART_KNOB | LV_STATE_DEFAULT);
       lv_obj_set_style_border_color(_arcTarget, lv_color_hex(0xC8C8C8), LV_PART_KNOB | LV_STATE_DEFAULT);
       lv_obj_set_style_border_opa(_arcTarget, 255, LV_PART_KNOB | LV_STATE_DEFAULT);
@@ -88,12 +91,12 @@ void classTile::_button(lv_obj_t *parent, const void *img)
   }
   
   lv_imgbtn_set_src(_btn, LV_IMGBTN_STATE_RELEASED, img, NULL, NULL);
-  lv_obj_set_style_bg_opa(_btn, WP_OPA_BG_OFF, LV_PART_MAIN | LV_IMGBTN_STATE_RELEASED);
+  lv_obj_set_style_bg_opa(_btn, opaBgOff, LV_PART_MAIN | LV_IMGBTN_STATE_RELEASED);
   lv_obj_set_style_img_recolor(_btn, lv_color_hex(0xffffff), LV_PART_MAIN | LV_IMGBTN_STATE_RELEASED);
   lv_obj_set_style_img_recolor_opa(_btn, 255, LV_PART_MAIN | LV_IMGBTN_STATE_RELEASED);
 
   lv_imgbtn_set_src(_btn, LV_IMGBTN_STATE_CHECKED_RELEASED, _imgOn, NULL, NULL);
-  lv_obj_set_style_bg_opa(_btn, WP_OPA_BG_ON, LV_STATE_CHECKED);
+  lv_obj_set_style_bg_opa(_btn, opaBgOn, LV_STATE_CHECKED);
   lv_obj_set_style_img_recolor(_btn, colorOn, LV_STATE_CHECKED);
   lv_obj_set_style_img_recolor_opa(_btn, 255, LV_STATE_CHECKED);
 
@@ -376,7 +379,7 @@ void classTile::setState(bool state)
   {
     if (lv_imgbtn_get_src_left(_btn, _state ? LV_IMGBTN_STATE_CHECKED_RELEASED : LV_IMGBTN_STATE_RELEASED))
       _hideThumbNail(false);
-}
+  }
 }
 
 lv_color_t classTile::getColor()
@@ -441,7 +444,7 @@ void classTile::updateBgColor(void)
     lv_obj_set_style_bg_opa(_tileBg, 0, LV_PART_MAIN);
   }
   if (_arcTarget)
-    lv_obj_set_style_bg_color(_arcTarget, lv_color_lighten(_tileBgColor, WP_OPA_BG_OFF), LV_PART_KNOB | LV_STATE_DEFAULT);
+    lv_obj_set_style_bg_color(_arcTarget, lv_color_lighten(_tileBgColor, opaBgOff), LV_PART_KNOB | LV_STATE_DEFAULT);
 }
 
 void classTile::setNumber(const char *value, const char *units, const char *subValue, const char *subUnits)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1998,6 +1998,11 @@ void jsonTileCommand(JsonVariant json)
     colorPicker.setState(newState == 0 ? false : true);
   }
 
+  if (json.containsKey("label"))
+  {
+    tile->setLabel(json["label"]);
+  }
+  
   if (json.containsKey("subLabel"))
   {
     tile->setSubLabel(json["subLabel"]);


### PR DESCRIPTION
tile `label ` can be changed with a tile cmnd/
```JSON
{
  "tiles": [
    {
      "screen": 1,
      "tile": 1,
      "state": "on",
      "label": "label text",
      "subLabel": "on just now"
    }
  ]
}
```

The brightness of the tile in OFF and ON state can be configured 
```JSON
{
	"tileBrightnessOff": <number  0 .. 25>,
	"tileBrightnessOn": <number 75 .. 100>
}
```
This configuration has to be sent to the panel before any tiles are configured to make sure it becomes active. (as custom icons)

