### PR TITLE
change screen navigation to swipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .vscode/launch.json
 .vscode/settings.json
 .vscode/ipch
+.vscode(extensions.json

--- a/include/classPopUpContainer.h
+++ b/include/classPopUpContainer.h
@@ -7,12 +7,11 @@ class classPopUpContainer
 {
 protected:
   classTile *_callingTile = NULL;
-  lv_obj_t *_parent = NULL;
+  lv_obj_t *_screen = NULL;
+  lv_obj_t *_parentScreen = NULL;
   lv_obj_t *_ovlPanel = NULL;
   lv_obj_t *_panel = NULL;
-  lv_obj_t *_btnExit = NULL;
 
-  static void _exitButtonEventHandler(lv_event_t *e);
   void _startUp(void);
 
 public:
@@ -20,5 +19,8 @@ public:
   classPopUpContainer(int start);
   void close(void);
   bool isActive(void);
-  classTile *getTile(void){return _callingTile;};
+  void addEventHandler(lv_event_cb_t callBack);
+  classTile *getTile(void) { return _callingTile; };
+  lv_obj_t *getScreen(void) { return _screen; };
+  lv_obj_t *getParentScreen(void) { return _parentScreen; };
 };

--- a/include/classScreen.h
+++ b/include/classScreen.h
@@ -10,11 +10,6 @@ private:
   lv_obj_t *_parent = NULL;
   lv_obj_t *_labelFooter = NULL;
   lv_obj_t *_labelWarning = NULL;
-  lv_obj_t *_btnHome = NULL;
-  lv_obj_t *_btnHomeImg;
-  lv_obj_t *_btnSettings = NULL;
-  lv_obj_t *_btnSettingsImg = NULL;
-  lv_obj_t *_btnFooter = NULL;
   lv_obj_t *_labelLeft = NULL;
   lv_obj_t *_labelCenter = NULL;
   lv_obj_t *_labelRight = NULL;
@@ -52,8 +47,6 @@ public:
   lv_color_t getBgColor(void);
   void updateBgColor(void);
 
-  void createHomeButton(lv_event_cb_t callBack, const void *img);
-  void createSettingsButton(lv_event_cb_t callBack, const void *img);
   void showConnectionStatus(bool connected);
   
   int getScreenNumber(void);

--- a/include/classScreenList.h
+++ b/include/classScreenList.h
@@ -20,6 +20,8 @@ public:
 
   void setIteratorStart(void);
   classScreen *getNextScreen(void);
+  classScreen* getNextScreen(int screenIdx);
+  classScreen* getPreviousScreen(int screenIdx);
 
   void remove(int screenIdx);
   bool exist(int screenIdx);

--- a/src/classes/classColorPicker.cpp
+++ b/src/classes/classColorPicker.cpp
@@ -196,8 +196,8 @@ void classColorPicker::_createColorPicker(lv_img_dsc_t *imgCw)
 
   // btn as "clone" from the calling tile
   _btn = lv_btn_create(_ovlPanel);
-  lv_obj_set_size(_btn, 153, 40);
-  lv_obj_align(_btn, LV_ALIGN_BOTTOM_RIGHT, -5, -5);
+  lv_obj_set_size(_btn, SCREEN_WIDTH - 10, 40);
+  lv_obj_align(_btn, LV_ALIGN_BOTTOM_MID , 0, -5);
   lv_obj_set_style_bg_color(_btn, lv_color_hex(0xffffff), LV_PART_MAIN | LV_STATE_DEFAULT);
   lv_obj_set_style_bg_opa(_btn, opaBgOff, LV_PART_MAIN | LV_STATE_DEFAULT);
   lv_obj_set_style_bg_color(_btn, lv_color_hex(0xffffff), LV_PART_MAIN | LV_STATE_CHECKED);
@@ -219,6 +219,7 @@ void classColorPicker::_createColorPicker(lv_img_dsc_t *imgCw)
   lv_obj_align(_panelCwFrame, LV_ALIGN_TOP_MID, 0, 25);
   lv_obj_clear_flag(_panelCwFrame, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_set_style_bg_opa(_panelCwFrame, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+  lv_obj_clear_flag(_panelCwFrame, LV_OBJ_FLAG_GESTURE_BUBBLE);
 
   // cw image
   _imgCw = lv_img_create(_panelCwFrame);

--- a/src/classes/classKeyPad.cpp
+++ b/src/classes/classKeyPad.cpp
@@ -19,12 +19,10 @@ static const char *btnm_map[] = {"1", "2", "3", "\n",
 
 void classKeyPad::_createKeyPad(void)
 {
-  int heightOffset = (!_callingTile) ? 45 : 0;
-  lv_obj_set_style_height(_panel, lv_obj_get_style_height(_panel, LV_PART_MAIN) + heightOffset, LV_PART_MAIN);
   _btnm1 = lv_btnmatrix_create(_panel);
   lv_obj_set_style_text_font(_btnm1, &lv_font_montserrat_20, LV_PART_ITEMS);
-  lv_obj_set_style_height(_btnm1, 320 + heightOffset, LV_PART_MAIN);
-  lv_obj_set_style_width(_btnm1, (320 + heightOffset) * 3 / 4, LV_PART_MAIN);
+  lv_obj_set_style_height(_btnm1, 365, LV_PART_MAIN);
+  lv_obj_set_style_width(_btnm1, 365 * 3 / 4, LV_PART_MAIN);
   lv_obj_set_style_bg_opa(_btnm1, 0, LV_PART_MAIN);
   lv_obj_set_style_radius(_btnm1, 80, LV_PART_ITEMS);
   lv_obj_set_style_bg_color(_btnm1, lv_color_hex(0xffffff), LV_PART_ITEMS);
@@ -78,9 +76,6 @@ classKeyPad::classKeyPad(classTile *tile, lv_event_cb_t keyPadEventHandler, keyP
   }
   _createKeyPad();
   _kpType = kpType;
-  // hide exit button if called by direct command (no parent tile)
-  if (!_callingTile)
-    lv_obj_add_flag(_btnExit, LV_OBJ_FLAG_HIDDEN);
   lv_obj_add_event_cb(_btnm1, keyPadEventHandler, LV_EVENT_SHORT_CLICKED, _callingTile);
 }
 

--- a/src/classes/classMessageFeed.cpp
+++ b/src/classes/classMessageFeed.cpp
@@ -11,7 +11,7 @@ classMessageFeed::classMessageFeed(classTile *tile) : classPopUpContainer(1)
 
   lv_obj_t *_flexGrid = lv_obj_create(_ovlPanel);
   lv_obj_remove_style_all(_flexGrid);
-  lv_obj_set_size(_flexGrid, SCREEN_WIDTH - 10, 480 - 40 - 5 * 3);
+  lv_obj_set_size(_flexGrid, SCREEN_WIDTH - 10, SCREEN_HEIGHT - 10);
   lv_obj_set_style_radius(_flexGrid, 5, 0);
   lv_obj_align(_flexGrid, LV_ALIGN_TOP_MID, 0, 5);
   lv_obj_set_flex_flow(_flexGrid, LV_FLEX_FLOW_COLUMN);

--- a/src/classes/classPopUpContainer.cpp
+++ b/src/classes/classPopUpContainer.cpp
@@ -9,8 +9,11 @@ extern int opaBgOn;
 // build the panels with all widgets
 void classPopUpContainer::_startUp(void)
 {
+  // new screen for pop-up 
+  _screen = lv_obj_create(NULL);
+
   // full screen overlay / opaqe
-  _ovlPanel = lv_obj_create(lv_scr_act());
+  _ovlPanel = lv_obj_create(_screen);
   lv_obj_remove_style_all(_ovlPanel);
   lv_obj_set_size(_ovlPanel, SCREEN_WIDTH, SCREEN_HEIGHT);
   lv_obj_set_align(_ovlPanel, LV_ALIGN_TOP_MID);
@@ -21,46 +24,35 @@ void classPopUpContainer::_startUp(void)
   // base panel
   _panel = lv_obj_create(_ovlPanel);
   lv_obj_remove_style_all(_panel);
-  lv_obj_set_size(_panel, SCREEN_WIDTH - 10, 480 - 40 - 5 * 3);
+  lv_obj_set_size(_panel, SCREEN_WIDTH - 10, SCREEN_HEIGHT - 10);
   lv_obj_align(_panel, LV_ALIGN_TOP_MID, 0, 5);
   lv_obj_set_style_radius(_panel, 5, LV_PART_MAIN | LV_STATE_DEFAULT);
   lv_obj_clear_flag(_panel, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_set_style_bg_color(_panel, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DEFAULT);
   lv_obj_set_style_bg_opa(_panel, opaBgOff, LV_PART_MAIN | LV_STATE_DEFAULT);
-
-  // back button (closes pop up)
-  _btnExit = lv_btn_create(_ovlPanel);
-  lv_obj_set_size(_btnExit, 153, 40);
-  lv_obj_align(_btnExit, LV_ALIGN_BOTTOM_LEFT, 5, -5);
-  lv_obj_set_style_bg_color(_btnExit, lv_color_hex(0xffffff), LV_PART_MAIN | LV_STATE_DEFAULT);
-  lv_obj_set_style_bg_opa(_btnExit, opaBgOff, LV_PART_MAIN | LV_STATE_DEFAULT);
-  lv_obj_t *label = lv_label_create(_btnExit);
-  lv_label_set_text(label, LV_SYMBOL_LEFT);
-  lv_obj_align(label, LV_ALIGN_CENTER, 0, 0);
-
-  lv_obj_add_event_cb(_btnExit, _exitButtonEventHandler, LV_EVENT_CLICKED, this);
 }
 
-// build the panels with all widgets (constructor)
+// build the panels with all widgets (constructor) and show on screen
 classPopUpContainer::classPopUpContainer(int start)
 {
+  _parentScreen = lv_scr_act();
   _startUp();
+  lv_disp_load_scr(_screen);
 }
 
-void classPopUpContainer::_exitButtonEventHandler(lv_event_t *e)
+void classPopUpContainer::addEventHandler(lv_event_cb_t callBack)
 {
-  lv_obj_t *btn = lv_event_get_target(e);
-  lv_obj_t *ovlPanel = lv_obj_get_parent(btn);
-  lv_obj_del(ovlPanel);
+  lv_obj_add_event_cb(_screen, callBack, LV_EVENT_GESTURE, this);
 }
 
 bool classPopUpContainer::isActive(void)
 {
-  return lv_obj_is_valid(_ovlPanel);
+  return lv_obj_is_valid(_screen);
 }
 
 void classPopUpContainer::close(void)
 {
-  lv_obj_del_delayed(_ovlPanel, 50);
-  _ovlPanel = NULL;
+  lv_disp_load_scr(_parentScreen);
+  lv_obj_del_delayed(_screen, 50);
+  _screen = NULL;
 }

--- a/src/classes/classScreen.cpp
+++ b/src/classes/classScreen.cpp
@@ -55,12 +55,6 @@ void classScreen::begin(int number, int style, int cols, int rows)
     container = cont;
   }
 
-  // middle "button" for screen selection drop down
-  _btnFooter = lv_imgbtn_create(screen);
-  lv_imgbtn_set_src(_btnFooter, LV_IMGBTN_STATE_RELEASED, NULL, NULL, NULL);
-  lv_obj_set_size(_btnFooter, 200, 40);
-  lv_obj_align(_btnFooter, LV_ALIGN_BOTTOM_MID, 0, 0);
-
   _labelFooter = lv_label_create(screen);
   lv_obj_align(_labelFooter, LV_ALIGN_BOTTOM_MID, 0, -5);
   lv_obj_set_style_text_font(_labelFooter, &lv_font_montserrat_20, 0);
@@ -142,15 +136,11 @@ void classScreen::setFooter(const char *left, const char *center, const char *ri
   if (!left)
   {
     lv_obj_add_flag(_labelLeft, LV_OBJ_FLAG_HIDDEN);
-    lv_obj_clear_flag(_btnHome, LV_OBJ_FLAG_HIDDEN);
-    lv_obj_clear_flag(_btnHomeImg, LV_OBJ_FLAG_HIDDEN);
   }
   else
   {
     lv_label_set_text(_labelLeft, left);
     lv_obj_clear_flag(_labelLeft, LV_OBJ_FLAG_HIDDEN);
-    lv_obj_add_flag(_btnHome, LV_OBJ_FLAG_HIDDEN);
-    lv_obj_add_flag(_btnHomeImg, LV_OBJ_FLAG_HIDDEN);
   }
 
   if (!center)
@@ -172,16 +162,12 @@ void classScreen::setFooter(const char *left, const char *center, const char *ri
     {
       lv_obj_add_flag(_labelRight, LV_OBJ_FLAG_HIDDEN);
       lv_obj_clear_flag(_labelRight, LV_OBJ_FLAG_USER_1);
-      lv_obj_clear_flag(_btnSettings, LV_OBJ_FLAG_HIDDEN);
-      lv_obj_clear_flag(_btnSettingsImg, LV_OBJ_FLAG_HIDDEN);
     }
     else
     {
       lv_label_set_text(_labelRight, right);
       lv_obj_clear_flag(_labelRight, LV_OBJ_FLAG_HIDDEN);
       lv_obj_add_flag(_labelRight, LV_OBJ_FLAG_USER_1);
-      lv_obj_add_flag(_btnSettings, LV_OBJ_FLAG_HIDDEN);
-      lv_obj_add_flag(_btnSettingsImg, LV_OBJ_FLAG_HIDDEN);
     }
   }
 }
@@ -214,37 +200,6 @@ lv_color_t classScreen::getBgColor(void)
   return _screenBgColor;
 }
 
-void classScreen::createHomeButton(lv_event_cb_t callBack, const void *img)
-{
-  _btnHome = lv_btn_create(screen);
-  lv_obj_set_size(_btnHome, 45, 40);
-  lv_obj_set_style_bg_opa(_btnHome, 0, LV_STATE_DEFAULT);
-  lv_obj_align(_btnHome, LV_ALIGN_BOTTOM_LEFT, 0, 0);
-  lv_obj_clear_flag(_btnHome, LV_OBJ_FLAG_PRESS_LOCK);
-  lv_obj_add_flag(_btnHome, LV_OBJ_FLAG_USER_1);
-  lv_obj_add_event_cb(_btnHome, callBack, LV_EVENT_ALL, this);
-  _btnHomeImg = lv_img_create(screen);
-  lv_img_set_src(_btnHomeImg, img);
-  lv_obj_align(_btnHomeImg, LV_ALIGN_BOTTOM_LEFT, 15, -6);
-
-  // set call back for center button
-  lv_obj_add_flag(_btnFooter, LV_OBJ_FLAG_USER_2);
-  lv_obj_add_event_cb(_btnFooter, callBack, LV_EVENT_ALL, this);
-}
-
-void classScreen::createSettingsButton(lv_event_cb_t callBack, const void *img)
-{
-  _btnSettings = lv_btn_create(screen);
-  lv_obj_set_size(_btnSettings, 45, 40);
-  lv_obj_set_style_bg_opa(_btnSettings, 0, LV_STATE_DEFAULT);
-  lv_obj_align(_btnSettings, LV_ALIGN_BOTTOM_RIGHT, 0, 0);
-  lv_obj_clear_flag(_btnSettings, LV_OBJ_FLAG_PRESS_LOCK);
-  lv_obj_add_flag(_btnSettings, LV_OBJ_FLAG_USER_3);
-  lv_obj_add_event_cb(_btnSettings, callBack, LV_EVENT_ALL, this);
-  _btnSettingsImg = lv_img_create(screen);
-  lv_img_set_src(_btnSettingsImg, img);
-  lv_obj_align(_btnSettingsImg, LV_ALIGN_BOTTOM_RIGHT, -15, -6);
-}
 
 void classScreen::showConnectionStatus(bool connected)
 {
@@ -255,8 +210,6 @@ void classScreen::showConnectionStatus(bool connected)
     if (lv_obj_has_flag(_labelRight, LV_OBJ_FLAG_USER_1))
     {
       lv_obj_clear_flag(_labelRight, LV_OBJ_FLAG_HIDDEN);
-      lv_obj_add_flag(_btnSettings, LV_OBJ_FLAG_HIDDEN);
-      lv_obj_add_flag(_btnSettingsImg, LV_OBJ_FLAG_HIDDEN);
     }
   }
   else
@@ -268,8 +221,6 @@ void classScreen::showConnectionStatus(bool connected)
     if (lv_obj_has_flag(_labelRight, LV_OBJ_FLAG_USER_1))
     {
       lv_obj_add_flag(_labelRight, LV_OBJ_FLAG_HIDDEN);
-      lv_obj_clear_flag(_btnSettings, LV_OBJ_FLAG_HIDDEN);
-      lv_obj_clear_flag(_btnSettingsImg, LV_OBJ_FLAG_HIDDEN);
     }
   }
 }

--- a/src/classes/classScreenList.cpp
+++ b/src/classes/classScreenList.cpp
@@ -127,6 +127,37 @@ classScreen *classScreenList::getNextScreen(void)
   }
 }
 
+// return next screen in list
+classScreen* classScreenList::getNextScreen(int screenIdx)
+{
+  it = std::find_if(std::begin(_listScreens), std::end(_listScreens),
+      [&](classScreen const& p)
+      { return p.screenIdx == screenIdx; });
+  it = std::find_if(++it, std::end(_listScreens), _isNotHidden);
+
+  if (it == _listScreens.end())
+    return NULL;
+  else
+    return it.operator->();
+}
+
+// return previous screen in list
+classScreen* classScreenList::getPreviousScreen(int screenIdx)
+{
+  it = std::find_if(std::begin(_listScreens), std::end(_listScreens),
+      [&](classScreen const& p)
+      { return p.screenIdx == screenIdx; });
+
+  if (it == _listScreens.begin())
+    return NULL;
+  it--;
+  while (it->isHidden())
+  {
+    it--;
+  }
+  return it.operator->();
+}
+
 // return size from list
 int classScreenList::getSize(void)
 {

--- a/src/classes/classScreenSettings.cpp
+++ b/src/classes/classScreenSettings.cpp
@@ -49,12 +49,12 @@ classScreenSettings::classScreenSettings(lv_obj_t *parent, const void *img)
   lv_obj_set_style_bg_color(_panelSlider, lv_color_hex(0xffffff), 0);
   lv_obj_set_style_bg_opa(_panelSlider, 40, 0);
   lv_obj_set_style_border_width(_panelSlider, 0, 0);
+  lv_obj_clear_flag(_panelSlider, LV_OBJ_FLAG_GESTURE_BUBBLE);
 
   // ui_Slider2
   _slider = lv_slider_create(_panelSlider);
   lv_slider_set_range(_slider, 1, 100);
   lv_slider_set_value(_slider, 50, LV_ANIM_OFF);
-  // if (lv_slider_get_mode(_slider) == LV_SLIDER_MODE_RANGE)
   lv_slider_set_left_value(_slider, 2, LV_ANIM_OFF);
   lv_obj_set_size(_slider, 280, 15);
   lv_obj_set_align(_slider, LV_ALIGN_BOTTOM_MID);
@@ -90,7 +90,7 @@ classScreenSettings::classScreenSettings(lv_obj_t *parent, const void *img)
   lv_obj_set_style_img_recolor(_btnRestart, lv_color_hex(0xffffff), LV_PART_MAIN | LV_IMGBTN_STATE_RELEASED);
   lv_obj_set_style_img_recolor_opa(_btnRestart, 255, LV_PART_MAIN | LV_IMGBTN_STATE_RELEASED);
   lv_obj_set_size(_btnRestart, 150, 50);
-  lv_obj_align_to(_btnRestart, _panelSlider, LV_ALIGN_OUT_BOTTOM_RIGHT, 0, 20);
+  lv_obj_align_to(_btnRestart, _panelSlider, LV_ALIGN_OUT_BOTTOM_RIGHT, 0, 10);
 
   lv_obj_t *_labelRestart = lv_label_create(_btnRestart);
   lv_obj_set_size(_labelRestart, LV_SIZE_CONTENT, LV_SIZE_CONTENT);

--- a/src/classes/classThermostat.cpp
+++ b/src/classes/classThermostat.cpp
@@ -42,6 +42,8 @@ void classThermostat::_createThermostat(void)
   lv_obj_set_style_border_side(_arcTarget, LV_BORDER_SIDE_FULL, LV_PART_KNOB | LV_STATE_DEFAULT);
   lv_obj_set_style_pad_all(_arcTarget, 7, LV_PART_KNOB | LV_STATE_DEFAULT);
 
+  lv_obj_clear_flag(_arcTarget, LV_OBJ_FLAG_GESTURE_BUBBLE);
+
   // label target
   _labelTarget = lv_label_create(_panel);
   lv_obj_set_size(_labelTarget, LV_SIZE_CONTENT, LV_SIZE_CONTENT);

--- a/src/classes/classTile.cpp
+++ b/src/classes/classTile.cpp
@@ -841,8 +841,12 @@ void classTile::setSliderState(int sliderState, lv_point_t point)
   switch (_sliderState)
   {
   case SL_STATE_OFF:
+    lv_obj_clear_state(_sliderHandle, LV_STATE_CHECKED);
+    lv_obj_add_flag(_btn, LV_OBJ_FLAG_GESTURE_BUBBLE);
+    break;
   case SL_STATE_ON:
     lv_obj_clear_state(_sliderHandle, LV_STATE_CHECKED);
+    lv_obj_clear_flag(_btn, LV_OBJ_FLAG_GESTURE_BUBBLE);
     break;
   case SL_STATE_ACTIVE:
     lv_obj_add_state(_sliderHandle, LV_STATE_CHECKED);


### PR DESCRIPTION
Major change of the screen navigation from "click" to "swipe" gestures

summary of changes and new features

-    navigation buttons removed from footers
-    no direkt button for the (rarely used) settings screen
-    hidden screens are not shown when swiping
-    simulatated animation when swiping thru screens (fading backlight)

screen Navigation
-    swipe left : next (higher) screen
-    swipe right : previous (lower) screen
-    swipe down : home screen (screen 1)
 -   swipe up : drop down screen select
 -   when on a pop-up screen : swipe down for return to parent screen (no other swipes from here)
